### PR TITLE
fixes to CheckRoomShouldBeDark

### DIFF
--- a/src/transparency.c
+++ b/src/transparency.c
@@ -10,8 +10,5 @@
  */
 u8 CheckRoomShouldBeDark(void)
 {
-    if (gEventCounter > EVENT_MORPH_BALL_ABILITY_RECOVERED)
-        return FALSE;
-
-    return TRUE;
+    return gEventCounter <= EVENT_SA_X_ELEVATOR_CUTSCENE_ENDS;
 }


### PR DESCRIPTION
fixes an error and now properly matches.

someone came in while I was working through it and quickly matched it, see https://decomp.me/scratch/1Z0Sc. 